### PR TITLE
Replaces legacy LongTensor constructor

### DIFF
--- a/gatr/utils/misc.py
+++ b/gatr/utils/misc.py
@@ -123,7 +123,7 @@ def make_full_edge_index(num_nodes, batchsize=1, self_loops=False, device=torch.
         src.append(i)
         dst.append(j)
 
-    edge_index_per_batch = torch.LongTensor([src, dst], device=device)
+    edge_index_per_batch = torch.tensor([src, dst], dtype=torch.int64, device=device)
 
     # Repeat for each batch element
     if batchsize > 1:


### PR DESCRIPTION
The legacy `torch.LongTensor` only expects `cpu` device type. If we want a `cuda` backend, we should add conditionals for `torch.cuda.LongTensor`. In my understanding, we should just use `torch.tensor` but specify the `dtype`.