### PR TITLE
Fix layernorm bug in baseline transformer

### DIFF
--- a/gatr/baselines/transformer.py
+++ b/gatr/baselines/transformer.py
@@ -35,7 +35,7 @@ class BaselineLayerNorm(nn.Module):
         outputs : Tensor
             Normalized inputs.
         """
-        return torch.nn.functional.layer_norm(inputs, normalized_shape=inputs.shape[1:])
+        return torch.nn.functional.layer_norm(inputs, normalized_shape=inputs.shape[-1:])
 
 
 class MultiHeadQKVLinear(nn.Module):


### PR DESCRIPTION
The `normalized_shape` parameter in `torch.nn.functional.layer_norm` specifies the dimensions to normalize, counting from the last dimension of the tensor. Currently, the implementation mistakenly uses all dimensions except the first one, when it should only include the last dimension.

This issue only affects the baseline transformer. In contrast, `normalized_shape` is used correctly within GATr, as seen in the implementation here: https://github.com/Qualcomm-AI-research/geometric-algebra-transformer/blob/main/gatr/layers/layer_norm.py#L67.