### PR TITLE
Consistent treatment for almost_unit_scalar initialization

### DIFF
--- a/gatr/layers/linear.py
+++ b/gatr/layers/linear.py
@@ -73,11 +73,11 @@ class EquiLinear(nn.Module):
         super().__init__()
 
         # Check inputs
-        if initialization == "unit_scalar":
-            assert bias, "unit_scalar initialization requires bias"
+        if initialization in ["unit_scalar", "almost_unit_scalar"]:
+            assert bias, "unit_scalar and almost_unit_scalar initialization requires bias"
             if in_s_channels is None:
                 raise NotImplementedError(
-                    "unit_scalar initialization is currently only implemented for scalar inputs"
+                    "unit_scalar and almost_unit_scalar initialization is currently only implemented for scalar inputs"
                 )
 
         self._in_mv_channels = in_mv_channels
@@ -244,24 +244,24 @@ class EquiLinear(nn.Module):
             s_factor = gain * additional_factor * np.sqrt(3)
             mvs_bias_shift = 0.0
         elif initialization == "small":
-            # Change scale by a factor of 0.3 in this layer
+            # Change scale by a factor of 0.1 in this layer
             mv_factor = 0.1 * gain * additional_factor * np.sqrt(3)
             s_factor = 0.1 * gain * additional_factor * np.sqrt(3)
             mvs_bias_shift = 0.0
         elif initialization == "unit_scalar":
-            # Change scale by a factor of 0.3 for MV outputs, and initialize bias around 1
+            # Change scale by a factor of 0.1 for MV outputs, and initialize bias around 1
             mv_factor = 0.1 * gain * additional_factor * np.sqrt(3)
             s_factor = gain * additional_factor * np.sqrt(3)
             mvs_bias_shift = 1.0
         elif initialization == "almost_unit_scalar":
-            # Change scale by a factor of 0.3 for MV outputs, and initialize bias around 1
+            # Change scale by a factor of 0.5 for MV outputs, and initialize bias around 1
             mv_factor = 0.5 * gain * additional_factor * np.sqrt(3)
             s_factor = gain * additional_factor * np.sqrt(3)
             mvs_bias_shift = 1.0
         else:
             raise ValueError(
                 f"Unknown initialization scheme {initialization}, expected"
-                ' "default", "small", or "unit_scalar".'
+                ' "default", "small", "unit_scalar" or "almost_unit_scalar".'
             )
 
         # Individual factors for each multivector component

--- a/tests/gatr/layers/test_linear.py
+++ b/tests/gatr/layers/test_linear.py
@@ -12,7 +12,7 @@ from tests.helpers import BATCH_DIMS, TOLERANCES, check_pin_equivariance
 @pytest.mark.parametrize(
     "in_s_channels, out_s_channels", [(None, None), (None, 100), (100, None), (32, 32)]
 )
-@pytest.mark.parametrize("initialization", ["default", "small", "unit_scalar"])
+@pytest.mark.parametrize("initialization", ["default", "small", "unit_scalar", "almost_unit_scalar"])
 def test_linear_layer_initialization(
     initialization,
     batch_dims,
@@ -68,6 +68,10 @@ def test_linear_layer_initialization(
         target_mean = torch.zeros_like(mv_mean)
         target_mean[0] = 1.0
         target_var = 0.01 * torch.ones_like(mv_var) / 3.0
+    elif initialization == "almost_unit_scalar":
+        target_mean = torch.zeros_like(mv_mean)
+        target_mean[0] = 1.0
+        target_var = 0.25 * torch.ones_like(mv_var) / 3.0
     else:
         raise ValueError(initialization)
 
@@ -83,7 +87,7 @@ def test_linear_layer_initialization(
 
         print(f"Output scalar: mean = {s_mean:.2f}, std = {s_var**0.5:.2f}")
         assert -0.3 < s_mean < 0.3
-        if initialization in {"default", "unit_scalar"}:
+        if initialization in {"default", "unit_scalar", "almost_unit_scalar"}:
             assert 1.0 / 3.0 / var_tolerance < s_var < 1.0 / 3.0 * var_tolerance
         else:
             assert 0.01 / 3.0 / var_tolerance < s_var < 0.01 / 3.0 * var_tolerance


### PR DESCRIPTION
The `almost_unit_scalar` initialization is default for one of the linear layers used to preprocess the inputs in the `GeometricBilinear` module. Probably this option was added later to replace `unit_scalar`, which is not used in the main code. 

Currently some checks in the main code and unit tests do not cover `almost_unit_scalar`, and sometimes the documentation is incomplete. This commit fixes that. It does not change any functionality as long as the `GATr` network is constructed in the default way.